### PR TITLE
formatting fixes(?)

### DIFF
--- a/server/formatter.js
+++ b/server/formatter.js
@@ -44,7 +44,7 @@ function normalizeHtml(html) {
   // empty element inside it. Do this at the 
   $('p').each((idx, el) => {
     if (el.children.length === 1 && el.children[0].tagName === 'span' && el.text() === '') {
-      $(el).remove();
+      $(el.children[0]).remove();
     }
   });
 

--- a/server/formatter.js
+++ b/server/formatter.js
@@ -41,7 +41,7 @@ function normalizeHtml(html) {
   // custom code added for SF Neo-Futurists
   // If there's a <p> containing nothing but a <span> with no text, delete the <span>. The stylesheet has
   // rules that are meant to let an empty paragraph take up space, but that doesn't work if it has another
-  // empty element inside it. Do this at the 
+  // empty element inside it.
   $('p').each((idx, el) => {
     if (el.children.length === 1 && el.children[0].tagName === 'span' && el.text() === '') {
       $(el.children[0]).remove();

--- a/server/formatter.js
+++ b/server/formatter.js
@@ -190,6 +190,7 @@ function fetchByline(html, creatorOfDoc) {
       s = s.replace(',', '')   // some people include commas
       s = s.replace(/\d+/, '') // cut out the year
       s = s.trim()             // cut out surrounding whitespace
+      s = s.replace(/^by /, '') // they might have written "Name" or "by Name"
       byline = s;
     }
 

--- a/server/formatter.js
+++ b/server/formatter.js
@@ -38,6 +38,16 @@ function normalizeHtml(html) {
     if (inTableOfContents) { $(p).remove() }
   })
 
+  // custom code added for SF Neo-Futurists
+  // If there's a <p> containing nothing but a <span> with no text, delete the <span>. The stylesheet has
+  // rules that are meant to let an empty paragraph take up space, but that doesn't work if it has another
+  // empty element inside it. Do this at the 
+  $('p').each((idx, el) => {
+    if (el.children.length === 1 && el.children[0].tagName === 'span' && el.text() === '') {
+      $(el).remove();
+    }
+  });
+
   // remove comments container in footer
   $('div').has('a[href^=#cmnt_ref][id^=cmnt]').remove()
 


### PR DESCRIPTION
Hey, so, I have no idea how to test this at all, and testing it would probably be a good idea before merging to the live site. But here's what I tried to do:

1. If there's anything that looks like `<p><span style="..."></span></p>` — that is, a `<p>` that contains nothing but a `<span>` and doesn't have any text — delete the `<span>`. This is to fix the situation I saw where a blank line was rendered as an invisible (zero-height) line if it had had any formatting, like italics, applied to its blank self; the problem was that the Library stylesheet allows a _totally empty_ `<p>` to take up space, but that doesn't work if it contains an element.
2. When extracting a name from a © line, if the word "by" appeared right after the ©, remove that. I noticed that all my plays were shown as "by by Eli Bishop" because I tend to write "© 2022 by Eli Bishop" instead of "© 2022 Eli Bishop".