### PR TITLE
Convert to an always-on F1 instance (and other related changes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,56 @@
 Library [![Build Status](https://cloud.drone.io/api/badges/nytimes/library/status.svg)](https://cloud.drone.io/nytimes/library) ![Supported node versions](https://img.shields.io/badge/dynamic/json?color=informational&label=node&query=%24.engines.node&url=https%3A%2F%2Fraw.githubusercontent.com%2Fnytimes%2Flibrary%2Fmain%2Fpackage.json)
 ========
 
+# SFNF Quickstart
+
+## Deploy commands
+Deploy to production: `gcloud app deploy --project sfneofuturists-chive`
+
+Deploy to staging (also see https://cloud.google.com/appengine/docs/flexible/testing-and-deploying-your-app?tab=node.js): `gcloud app deploy --no-promote --project sfneofuturists-chive --version staging`
+
+## Using the staging environment
+Always try out changes in the staging environment first!
+
+Staging URL: https://staging-dot-sfneofuturists-chive.wn.r.appspot.com/
+
+You can temporarily route traffic through the main chive URL to staging in [Versions](https://console.cloud.google.com/appengine/versions) -> Migrate Traffic
+
+## Secrets, secrets
+.env file template:
+```bash
+# node environment (development or production)
+NODE_ENV=production
+# Google oAuth credentials
+GOOGLE_CLIENT_ID=962567839872-4c94dhvchhtnpf5ajedc6p1nuboqeimq.apps.googleusercontent.com
+# retrieve this from Cloud Console (APIs & Services -> Credentials -> sfneofuturists-chive -> download JSON secret)
+GOOGLE_CLIENT_SECRET=REPLACEME
+GCP_PROJECT_ID=sfneofuturists-chive
+# allow-list of fully-qualified email addresses or domains
+# we might want to improve access on this at some point, pretty sure right now anyone can access chive?
+# no real reason to limit to just gmail/hotmail either
+APPROVED_DOMAINS="gmail.com,hotmail.com"
+# Generate a random string for this; ideally we would sync it between everyone who deploys, but not sure how much it matters
+SESSION_SECRET=REPLACEME
+
+# team or folder (we're not using GSuite, so has to be folder)
+DRIVE_TYPE=folder
+# the ID of your team's drive or shared folder. The string of random numbers and letters at the end of your team drive or folder url.
+DRIVE_ID=1w5VMeTMwG5mC3apzYqM6C9JRelBhqUwO
+
+# download a new version of .auth.json from Cloud Console and place it in your copy of the repo
+# (APIs & Services -> Credentials -> sfneofuturists-chive@sfneofuturists-chive.iam.gserviceaccount.com ->
+#  Keys -> Add Key -> Create new key)
+# note: no need to change this line, it just has to not be "parse_json" to make it look for the file
+GOOGLE_APPLICATION_CREDENTIALS=.auth.json
+
+# alternative: uncomment these 2 lines, download .auth.json as above, and paste its contents here instead
+# also need to remove the other GOOGLE_APPLICATION_CREDENTIALS line
+# GOOGLE_APPLICATION_CREDENTIALS=parse_json
+# GOOGLE_APPLICATION_JSON=PASTE_RAW_JSON_HERE
+```
+
+# Original NYT Documentation
+
 A collaborative newsroom documentation site, powered by Google Docs.
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->

--- a/app.yaml
+++ b/app.yaml
@@ -3,10 +3,27 @@
 # Note: Library currently does not run under Node.js 20, will need to pull
 #       changes from upstream closer to v18 EOL
 runtime: nodejs18
-instance_class: F4
+
+# Capability table: https://cloud.google.com/appengine/docs/standard#instance_classes
+# Cost table: https://cloud.google.com/appengine/pricing (go to us-west4)
+# F1: 384MB mem / 600MHz CPU / supports automatic scaling / $0.055/hr
+instance_class: F1
+
+automatic_scaling:
+  # default 0.6; attempt to avoid spurious creation of extra instances
+  target_cpu_utilization: 0.8
+  target_throughput_utilization: 0.8
+  # ensures at least one instance is always running, to avoid a ~30sec startup penalty
+  # note: does not apply in staging (version must be configured to receive traffic)
+  # https://cloud.google.com/appengine/docs/standard/reference/app-yaml?tab=node.js#scaling_elements
+  min_instances: 1
 
 handlers:
 - url: /.*
   secure: always
   redirect_http_response_code: 301
   script: auto
+
+inbound_services:
+# required for min_instances to work
+- warmup

--- a/app.yaml
+++ b/app.yaml
@@ -1,4 +1,8 @@
-runtime: nodejs16
+# Node.js 18 is EOL on April 30, 2025
+# https://github.com/nodejs/release#release-schedule
+# Note: Library currently does not run under Node.js 20, will need to pull
+#       changes from upstream closer to v18 EOL
+runtime: nodejs18
 instance_class: F4
 
 handlers:

--- a/server/index.js
+++ b/server/index.js
@@ -36,6 +36,13 @@ app.get('/healthcheck', (req, res) => {
   res.send('OK')
 })
 
+// Handle warmup requests in a bare-minimum fashion
+// Could also use this hook to start up middleware etc, but not worth it for our use case
+// https://cloud.google.com/appengine/docs/standard/configuring-warmup-requests?tab=node.js
+app.get('/_ah/warmup', (req, res) => {
+  res.send('OK')
+});
+
 app.use(csp({directives: customCsp}))
 app.use(userAuth)
 


### PR DESCRIPTION
## Changes
* Convert to a smaller F1 instance which is always-on
* Improve bootstrap documentation for SFNF contributors
* Update Node.js to v18 (v16 is EOL)

## Testing
* Deployed this branch to staging version (see additions to README); observed that app worked normally, though instance did not stay on for more than 15min (this appears to be expected, traffic must be routed to the version in order for min_instances to take effect)
* Routed traffic to staging version and observed that instance stayed on for over an hour (presumably indefinitely)
* Checked that hammering the site from multiple browser tabs didn't explode anything
* Reverted traffic to previous mainline version while I wait for approval on this PR

## Billing
I intend to let this run for a week or so, then check back to see what effect it has on our bill. Google Cloud doesn't have good forecasting so I think the best way to check how much we're being charged is to just... try it out. (It should be comparable to what we're already paying, though, which is not much.)

## Caveat...
The downside to this change is that people hammering the chive on Tuesdays will spin up extra instances since F1 is smaller. Hopefully not too many, though.