### PR TITLE
Add TRUST_PROXY to env, so that we can remove HTTP OAuth callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,12 @@ GCP_PROJECT_ID=sfneofuturists-chive
 # we might want to improve access on this at some point, pretty sure right now anyone can access chive?
 # no real reason to limit to just gmail/hotmail either
 APPROVED_DOMAINS="gmail.com,hotmail.com"
-# Generate a random string for this; ideally we would sync it between everyone who deploys, but not sure how much it matters
+# Generate a random string for this; if this changes between deploys, users will have to log in again
 SESSION_SECRET=REPLACEME
+# needed in order to generate an HTTPS OAuth2 callback URL in userAuth.js
+# Google App Engine is behind an nginx reverse proxy: https://issuetracker.google.com/issues/70018870#comment2
+# Also see https://expressjs.com/en/guide/behind-proxies.html
+TRUST_PROXY=true
 
 # team or folder (we're not using GSuite, so has to be folder)
 DRIVE_TYPE=folder


### PR DESCRIPTION
Our callback URI from OAuth2 uses HTTP, not HTTPS, because Express is unaware that it is behind a reverse proxy handling the HTTPS logic. Setting TRUST_PROXY=true in .env will allow Express to generate the HTTPS version of the callback URI.

(Google App Engine places all flexible instances behind nginx, a reverse proxy.)

Enabling this feature is important both for data security, and for using other features of the Drive API that are gated behind having a secure app.

Testing process:
1. Clear cookies for staging env on client side (to force re-login)
2. Remove HTTP staging URI from OAuth2 whitelist
3. Attempt to log in - rejected for `Error 400: redirect_uri_mismatch`
4. Deploy this branch to staging
5. Attempt to log in - success!