### PR TITLE
Add logout button and restore error page content

### DIFF
--- a/custom/styles/_custom.scss
+++ b/custom/styles/_custom.scss
@@ -1,8 +1,3 @@
-// Don't take up extra vertical space.
-.tagline {
-  display: none;
-}
-
 // Reduce space between logo and heading.
 #main-search-page .main-item .branding .branding-label {
   padding-left: 0;

--- a/layouts/partials/userTools.ejs
+++ b/layouts/partials/userTools.ejs
@@ -6,6 +6,7 @@
 
       <i class="fa fa-angle-down" aria-hidden="true"></i>
     </a>
+    <a id="logout" href="/logout" class="btn-user-whole">Log Out</a>
   </div>
 
   <div id="me" class="overlay">


### PR DESCRIPTION
Per comments in #4, splitting this commit out into a separate PR for clarity. This makes 2 changes:
1. Adds a Log Out button to the logged-in screens (not visible when not authenticated or authenticated with an unauthorized account). This makes testing user auth easier, and is also just a good thing to have.
![Screenshot 2024-04-22_22-15-25](https://github.com/sfneofuturists/chive/assets/682349/c7ecb7cf-3abb-45c2-a75e-04f0906eeb0f)

2. Reverts an old change that unexpectedly hid error messages in order to save some vertical space on the home page. @clizzin, as you requested in the other PR, I restored the vertical gap on the main page to diverge less from upstream; let me know if you think the gap is too much and I can remove it again 😂.

----
![Screenshot 2024-04-22_22-57-19](https://github.com/sfneofuturists/chive/assets/682349/b227c06a-3ed2-4fe4-aedf-1950e83c0836)
----
![Screenshot 2024-04-22_22-19-37](https://github.com/sfneofuturists/chive/assets/682349/a9a119f7-52b9-4ee9-a0f6-5c55ab4ba3af)
----
![Screenshot 2024-04-22_22-20-53](https://github.com/sfneofuturists/chive/assets/682349/c5fb52ec-c638-4951-a095-ef40c07ad003)
----
![Screenshot 2024-04-22_22-59-35](https://github.com/sfneofuturists/chive/assets/682349/93c6544f-19b6-4a3a-9c66-dd721cb71a53)
----