### PR TITLE
Update to nodejs v24

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ SESSION_SECRET=REPLACEME
 # Also see https://expressjs.com/en/guide/behind-proxies.html
 TRUST_PROXY=true
 
-# NB: APPROVED_DOMAINS not needed for our version of the project
+# allow-list of fully-qualified email addresses or domains
+# we might want to improve access on this at some point, pretty sure right now anyone can access chive?
+# no real reason to limit to just gmail/hotmail either
+APPROVED_DOMAINS="gmail.com,hotmail.com"
 
 # team or folder (we're not using GSuite, so has to be folder)
 DRIVE_TYPE=folder

--- a/app.yaml
+++ b/app.yaml
@@ -1,8 +1,6 @@
-# Node.js 18 is EOL on April 30, 2025
+# Node.js 24 is EOL on April 30, 2028
 # https://github.com/nodejs/release#release-schedule
-# Note: Library currently does not run under Node.js 20, will need to pull
-#       changes from upstream closer to v18 EOL
-runtime: nodejs18
+runtime: nodejs24
 
 # Capability table: https://cloud.google.com/appengine/docs/standard#instance_classes
 # Cost table: https://cloud.google.com/appengine/pricing (go to us-west4)

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,6 +73,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.10.5.tgz",
       "integrity": "sha512-O34LQooYVDXPl7QWCdW9p4NR+QlzOr7xShPPJz8GsuCU3/8ua/wqTr7gmnxXv+WBESiGU/G5s16i6tUvHkNb+w==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/generator": "^7.10.5",
@@ -1662,6 +1663,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3380,7 +3382,6 @@
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
       }
@@ -3390,7 +3391,6 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -3600,6 +3600,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.17.0.tgz",
       "integrity": "sha512-zJk08MiBgwuGoxes5sSQhOtibZ75pz0J35XTRlZOk9xMffhpA9BTbQZxoXZzOl5zMbleShbGwtw+1kGferfFwQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "@eslint/eslintrc": "^0.2.2",
@@ -3709,6 +3710,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.0.tgz",
       "integrity": "sha512-66Fpf1Ln6aIS5Gr/55ts19eUuoDhAbZgnr6UxK5hbDx6l/QgQgx61AePq+BV4PP2uXQFClgMVzep5zZ94qqsxg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.1",
         "array.prototype.flat": "^1.2.3",
@@ -3824,6 +3826,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
       "integrity": "sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "eslint-plugin-es": "^3.0.0",
         "eslint-utils": "^2.0.0",
@@ -3862,6 +3865,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz",
       "integrity": "sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -3871,6 +3875,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.0.1.tgz",
       "integrity": "sha512-v/KBnfyaOMPmZc/dmc6ozOdWqekGp7bBGq4jLAecEfPGmfKiWS4sA8sC0LqiV9w5qmXAtXVn4M3p1jSyhY85SQ==",
       "dev": true,
+      "peer": true,
       "peerDependencies": {
         "eslint": ">=5.0.0"
       }
@@ -11381,6 +11386,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.10.5.tgz",
       "integrity": "sha512-O34LQooYVDXPl7QWCdW9p4NR+QlzOr7xShPPJz8GsuCU3/8ua/wqTr7gmnxXv+WBESiGU/G5s16i6tUvHkNb+w==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
         "@babel/generator": "^7.10.5",
@@ -12596,7 +12602,8 @@
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "acorn-globals": {
       "version": "6.0.0",
@@ -13920,7 +13927,6 @@
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
       "optional": true,
-      "peer": true,
       "requires": {
         "iconv-lite": "^0.6.2"
       },
@@ -13930,7 +13936,6 @@
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
           "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
           "optional": true,
-          "peer": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3.0.0"
           }
@@ -14095,6 +14100,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.17.0.tgz",
       "integrity": "sha512-zJk08MiBgwuGoxes5sSQhOtibZ75pz0J35XTRlZOk9xMffhpA9BTbQZxoXZzOl5zMbleShbGwtw+1kGferfFwQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "@eslint/eslintrc": "^0.2.2",
@@ -14233,6 +14239,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.0.tgz",
       "integrity": "sha512-66Fpf1Ln6aIS5Gr/55ts19eUuoDhAbZgnr6UxK5hbDx6l/QgQgx61AePq+BV4PP2uXQFClgMVzep5zZ94qqsxg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "array-includes": "^3.1.1",
         "array.prototype.flat": "^1.2.3",
@@ -14323,6 +14330,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
       "integrity": "sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==",
       "dev": true,
+      "peer": true,
       "requires": {
         "eslint-plugin-es": "^3.0.0",
         "eslint-utils": "^2.0.0",
@@ -14350,13 +14358,15 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz",
       "integrity": "sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "eslint-plugin-standard": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.0.1.tgz",
       "integrity": "sha512-v/KBnfyaOMPmZc/dmc6ozOdWqekGp7bBGq4jLAecEfPGmfKiWS4sA8sC0LqiV9w5qmXAtXVn4M3p1jSyhY85SQ==",
       "dev": true,
+      "peer": true,
       "requires": {}
     },
     "eslint-scope": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "valid-url": "^1.0.9"
       },
       "engines": {
-        "node": ">=18.x",
+        "node": ">=24.x",
         "npm": ">=8.x"
       }
     },
@@ -5404,11 +5404,6 @@
       "engines": {
         "node": ">=4.0.0"
       }
-    },
-    "node_modules/googleapis/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/googleapis/node_modules/node-forge": {
       "version": "0.9.1",
@@ -15369,11 +15364,6 @@
           "version": "2.4.4",
           "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
           "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
-        },
-        "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         },
         "node-forge": {
           "version": "0.9.1",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "url": "https://github.com/nytimes/library/issues"
   },
   "engines": {
-    "node": ">=18.x",
+    "node": ">=24.x",
     "npm": ">=8.x"
   },
   "homepage": "https://github.com/nytimes/library#readme"


### PR DESCRIPTION
Updates us to node v24, which will last us until 2028. Doesn't seem to cause any issues. Not sure why the ms packages disappeared when I ran `npm install` but that doesn't appear to cause issues either.