### PR TITLE
Ignore prefix numbers in titles only if followed by delimiter

### DIFF
--- a/server/text.js
+++ b/server/text.js
@@ -4,7 +4,8 @@ exports.cleanName = (name = '') => {
   return name
     .trim()
     // eslint-disable-next-line no-useless-escape
-    .replace(/^(\d+[-–—_\s]*)([^\d\/\-^\s]+)/, '$2') // remove leading numbers and delimiters
+    //.replace(/^(\d+[-–—_\s]*)([^\d\/\-^\s]+)/, '$2') // remove leading numbers and delimiters
+    .replace(/^(\d+\s+[-–—_]+\s+)([^\d\/\-^\s]+)/, '$2') // remove leading numbers and delimiters
     .replace(/\s*\|\s*([^|]+)$/i, '') // remove trailing pipe and tags
 
     // commented out for SF Neo-Futurists b/c some play titles use periods in


### PR DESCRIPTION
Meaningful numbers were being cut out, e.g. "447" in "447 Minna" and "1997:" in Andie's 1997 play from "30 Plays for 30 Years."

This is a redo of 48171ef. The custom logic was accidentally eliminated when we merged upstream and the definition of `cleanName` got moved from `server/docs.j` to `server/text.js`.