### PR TITLE
Fix display of blank lines with italics or other formatting

### DIFF
--- a/server/formatter.js
+++ b/server/formatter.js
@@ -43,9 +43,13 @@ function normalizeHtml(html) {
   // If there's a <p> containing nothing but a <span> with no text, delete the <span>. The stylesheet has
   // rules that are meant to let an empty paragraph take up space, but that doesn't work if it has another
   // empty element inside it.
-  $('p').each((idx, el) => {
-    if (el.children.length === 1 && el.children[0].tagName === 'span' && el.children[0].textContent === '') {
-      $(el.children[0]).remove();
+  $p.each((idx, p) => {
+    if (p.children.length != 1) return
+    if (p.children[0].tagName != 'span') return
+
+    const span = $(p.children[0])
+    if (span.text() == '') {
+      span.remove()
     }
   });
 


### PR DESCRIPTION
Usually blank lines in a Google Doc are empty `p` elements. Library uses CSS to give empty `p` tags a fixed height, so that it looks like there's a blank line in the displayed HTML.

But when a blank line in the Google Doc is italicized or has other formatting, the `p` element contains an empty `span` element, and the CSS rule doesn't apply. We previously tried to fix this in https://github.com/sfneofuturists/chive/pull/1 but there was a bug: `textContent` returned `undefined`, not an empty string. This commit fixes by using Cheerio's `text()` method instead.

I manually tested this in my development environment using a doc that had an italicized blank line.